### PR TITLE
Add ability to block a signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ sig.emit();
 print(text); // func2 func3 func1
 ```
 
+### Blocking signals and connection
+Signals and connections can be blocked using the 'blocked' member variable. Signals are blocked to prevent them from emitting when emit is called. Connections can be blocked to prevent signals from executing the slot they are subscribed with.
+
+```dart
+Signal sig = Signal();
+Connection connection0 = sig.connect((){ print("slot 0"); });
+Connection connection1 = sig.connect((){ print("slot 1"); });
+sig.emit(); // 'slot 0' and 'slot 1' are printed
+
+// Blocked signal example
+sig.blocked = true;
+sig.emit(); // Nothing is printed
+sig.blocked = false;
+
+// Blocked connection example
+connection0.blocked = true;
+sig.emit(); // Only 'slot 1' is printed
+```
+
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [contributors-shield]: https://img.shields.io/github/contributors/voidari/flutter_signals_slots.svg?style=for-the-badge

--- a/lib/src/signal.dart
+++ b/lib/src/signal.dart
@@ -9,6 +9,10 @@ class Signal {
   /// The list of functions registered to the signal
   final Map<int, List<Connection>> _connectionMap = <int, List<Connection>>{};
 
+  /// The blocked status of the signal. Signals that are blocked will
+  /// return an empty list.
+  bool blocked = false;
+
   /// Provides the means to connect a slot [function] to a signal.
   /// Signals emitted will execute each [group] in acending order
   /// with the default of 0. The [insertAtIndex] can be used to specify
@@ -92,6 +96,10 @@ class Signal {
       dynamic p9]) async {
     // The list of returned values from each function
     List<dynamic> retList = <dynamic>[];
+    // Determine if the signal has been blocked.
+    if (blocked) {
+      return retList;
+    }
     // Iterate over each subscribed function after sorting the
     // order of groups.
     List<int> groups = _connectionMap.keys.toList();

--- a/test/signals_slots_test.dart
+++ b/test/signals_slots_test.dart
@@ -141,6 +141,31 @@ void main() {
     expect(count, 1);
   });
 
+  test('Blocking Signals (Beginner)', () async {
+    Signal sig = Signal();
+    int count = 0;
+    sig.connect(() {
+      count++;
+    });
+
+    // Before block
+    count = 0;
+    sig.emit();
+    expect(count, 1);
+
+    // After block
+    count = 0;
+    sig.blocked = true;
+    sig.emit();
+    expect(count, 0);
+
+    // After unblock
+    count = 0;
+    sig.blocked = false;
+    sig.emit();
+    expect(count, 1);
+  });
+
   test('Reconnection example', () async {
     Signal sig = Signal();
     bool isCalled = false;


### PR DESCRIPTION
Adds a blocked member variable to Signal to track the signal being blocked. If blocked, emit will always return an empty list.

Resolves #1